### PR TITLE
Add beer tally logic with only register/unregister for now

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,6 +55,7 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 name = "beer-tally-telegram-bot"
 version = "0.1.0"
 dependencies = [
+ "lazy_static",
  "log",
  "pretty_env_logger",
  "teloxide",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ teloxide = { version = "0.5", features = ["macros", "auto-send"] }
 log = "0.4"
 pretty_env_logger = "0.4.0"
 tokio = { version =  "1.8", features = ["rt-multi-thread", "macros"] }
+lazy_static = "1.4.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,23 +2,63 @@ use teloxide::{prelude::*, utils::command::BotCommand};
 
 use std::error::Error;
 
+mod storage;
+use lazy_static::lazy_static;
+use std::sync::Mutex;
+use storage::{BeerTally, HashMapBeerTally, RegisterPlayerResult};
+
+lazy_static! {
+    static ref STORAGE: Mutex<Box<dyn BeerTally + Send + Sync>> =
+        Mutex::new(Box::new(HashMapBeerTally::new()));
+}
+
 #[derive(BotCommand)]
 #[command(rename = "lowercase", description = "These commands are supported:")]
 enum Command {
     #[command(description = "display this text.")]
     Help,
-    #[command(description = "select someone who has to pay the beers.")]
-    PayTheBeers(String),
+    #[command(description = "register as a player.")]
+    Register(String),
+    #[command(description = "unregister as a player.")]
+    Unregister,
 }
 
 async fn answer(
     cx: UpdateWithCx<AutoSend<Bot>, Message>,
     command: Command,
 ) -> Result<(), Box<dyn Error + Send + Sync>> {
+    let chat_id = cx.update.chat_id();
+    let user_id = cx.update.from().unwrap().id;
+
     match command {
         Command::Help => cx.answer(Command::descriptions()).await?,
-        Command::PayTheBeers(username) => {
-            cx.answer(format!("{} pays the beers 🍻", username)).await?
+        Command::Register(username) => {
+            let return_string = match STORAGE
+                .lock()
+                .unwrap()
+                .register_player(chat_id, user_id, &username)
+            {
+                RegisterPlayerResult::InvalidUsername => {
+                    String::from("Invalid username. Only alphanumeric characters are allowed.")
+                }
+                RegisterPlayerResult::Registered => {
+                    format!("Successfully registered as '{}'.", &username)
+                }
+                RegisterPlayerResult::AlreadyRegistered(existing_name) => {
+                    format!("You are already registered as '{}'. Use command /change_name to change your username.", existing_name)
+                }
+                RegisterPlayerResult::UsernameTaken => {
+                    format!("Username '{}' is already taken.", &username)
+                }
+            };
+            cx.answer(return_string).await?
+        }
+        Command::Unregister => {
+            let return_string = match STORAGE.lock().unwrap().unregister_player(chat_id, user_id) {
+                Ok(_) => String::from("Successfully unregistered."),
+                Err(_) => String::from("You were not registered."),
+            };
+            cx.answer(return_string).await?
         }
     };
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,0 +1,75 @@
+pub enum RegisterPlayerResult {
+    InvalidUsername,
+    AlreadyRegistered(String),
+    UsernameTaken,
+    Registered,
+}
+
+pub trait BeerTally {
+    fn register_player(
+        &mut self,
+        chat_id: i64,
+        user_id: i64,
+        username: &str,
+    ) -> RegisterPlayerResult;
+    fn unregister_player(&mut self, chat_id: i64, user_id: i64) -> Result<(), ()>;
+}
+
+use std::collections::HashMap;
+
+pub struct HashMapBeerTally {
+    /// Player names for a given chat id and user id.
+    /// In other words, the same user can participate in multiple chats.
+    players: HashMap<i64, HashMap<i64, String>>,
+}
+
+impl HashMapBeerTally {
+    pub fn new() -> HashMapBeerTally {
+        HashMapBeerTally {
+            players: HashMap::new(),
+        }
+    }
+}
+
+impl BeerTally for HashMapBeerTally {
+    fn register_player(
+        &mut self,
+        chat_id: i64,
+        user_id: i64,
+        username: &str,
+    ) -> RegisterPlayerResult {
+        if username.is_empty() || !username.chars().all(char::is_alphanumeric) {
+            return RegisterPlayerResult::InvalidUsername;
+        }
+
+        match self.players.get_mut(&chat_id) {
+            None => {
+                let mut usernames = HashMap::new();
+                usernames.insert(user_id, username.to_string());
+                self.players.insert(chat_id, usernames);
+                RegisterPlayerResult::Registered
+            }
+            Some(usernames) => {
+                if let Some(registered_username) = usernames.get(&user_id) {
+                    return RegisterPlayerResult::AlreadyRegistered(
+                        registered_username.to_string(),
+                    );
+                } else if usernames.values().any(|x| x == username) {
+                    return RegisterPlayerResult::UsernameTaken;
+                }
+                usernames.insert(user_id, username.to_string());
+                RegisterPlayerResult::Registered
+            }
+        }
+    }
+
+    fn unregister_player(&mut self, chat_id: i64, user_id: i64) -> Result<(), ()> {
+        match self.players.get_mut(&chat_id) {
+            None => Err(()),
+            Some(usernames) => match usernames.remove(&user_id) {
+                Some(_) => Ok(()),
+                None => Err(()),
+            },
+        }
+    }
+}


### PR DESCRIPTION
This PR adds two new commands:
  - `/register <username>`
  - `/unregister`

When run in privacy mode (default), the bot cannot retrieve the chat member list. For that reason every user that wants to participate has to register with the bot first so it knows who's participating in the game.

I added a simple nested hashmap implementation (`hashmap<group_id, hashmap<user_id, username>>`) which stores who is participating in which group with what username as a hashmap in memory. In the future we will probably use a database as storage backend to not lose all data during restarts, but to get started with Rust this seems simpler.

![image](https://user-images.githubusercontent.com/9250155/144896231-072bc50d-9828-4148-990c-96e50a1bba4d.png)


Next steps would be to add the following commands:
  - `/list_players` - List all registered players in the current chat
  - `/random` - Choose a random player from the registered players in the chat
  - `/change_name <username>` - Allow a user to change their username
  - `/start` - Display something e.g. the command list.
