### PR TITLE
User tally

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,6 +55,7 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 name = "beer-tally-telegram-bot"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "lazy_static",
  "log",
  "pretty_env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ pretty_env_logger = "0.4.0"
 tokio = { version =  "1.8", features = ["rt-multi-thread", "macros"] }
 lazy_static = "1.4.0"
 rand = "*"
+chrono = "*"

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,8 @@ enum Command {
     PlayerList,
     #[command(description = "Chooses a random player.")]
     Random,
+    #[command(description = "Adds a record for the current player.")]
+    Record(f32),
 }
 
 async fn answer(
@@ -75,6 +77,14 @@ async fn answer(
 
         Command::Random => {
             let return_string = STORAGE.lock().unwrap().get_random(chat_id);
+            cx.answer(return_string).await?
+        }
+
+        Command::Record(value) => {
+            let return_string = match STORAGE.lock().unwrap().add_record(chat_id, user_id, value) {
+                Ok(msg) =>  format!("{}", msg),
+                Err(msg) => format!("{}", msg)
+            };
             cx.answer(return_string).await?
         }
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ use teloxide::{prelude::*, utils::command::BotCommand};
 use std::error::Error;
 
 mod storage;
+mod tally;
 use lazy_static::lazy_static;
 use std::sync::Mutex;
 use storage::{BeerTally, HashMapBeerTally, RegisterPlayerResult};

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -18,6 +18,7 @@ pub trait BeerTally {
     fn unregister_player(&mut self, chat_id: i64, user_id: i64) -> Result<(), ()>;
     fn player_list(&mut self, chat_id: i64) -> String;
     fn get_random(&mut self, chat_id: i64) -> String;
+    fn add_record(&mut self, chat_id: i64, user_id: i64, value: f32) -> Result<&str, &str>;
 }
 
 use std::collections::HashMap;
@@ -56,9 +57,9 @@ impl BeerTally for HashMapBeerTally {
                 RegisterPlayerResult::Registered
             }
             Some(usernames) => {
-                if let Some(registered_tally) = usernames.get(&user_id) {
+                if let Some(user_tally) = usernames.get(&user_id) {
                     return RegisterPlayerResult::AlreadyRegistered(
-                        registered_tally.name.clone(),
+                        user_tally.name.clone(),
                     );
                 } else if usernames.values().any(|x| x.name == username) {
                     RegisterPlayerResult::UsernameTaken
@@ -118,5 +119,20 @@ impl BeerTally for HashMapBeerTally {
 
         let rng = rand::thread_rng().gen_range(0..my_players.len());
         format!("{}", my_players[rng].name).to_string()
+    }
+
+    fn add_record(&mut self, chat_id: i64, user_id: i64, value: f32) -> Result<&str, &str> {
+        if let Some(chat) = self.players.get_mut(&chat_id) {
+            if chat.is_empty() {
+                Err("No users have been initialized in this chat, try to register some users first")
+            } else if let Some(user) = chat.get_mut(&user_id) {
+                user.add_record(value)
+            } else {
+                // This should not happen
+                Err("The user was not found")
+            }
+        } else {
+            Err("No users have been registered yet")
+        }
     }
 }

--- a/src/tally.rs
+++ b/src/tally.rs
@@ -1,8 +1,24 @@
+use chrono::{Datelike, Utc};
+
+#[derive (Debug, Clone)]
+struct Date {
+    year: u32,
+    day: u32,
+    month: u32
+}
+
+impl Default for Date {
+    fn default() -> Date {
+        Date { year: 0, day: 0, month: 0 }
+    }
+}
+
 #[derive(Clone)]
 #[derive (Debug)]
 pub struct UserTally {
     pub name: String,
-    pub records: Vec<i32>
+    pub records: Vec<f32>,
+    modified_date: Date
 }
 
 impl UserTally {
@@ -10,7 +26,35 @@ impl UserTally {
     pub fn new(username: &str) -> UserTally {
         UserTally {
             name: username.to_string(),
-            records: Vec::new()
+            records: Vec::new(),
+            modified_date: Date::default()
         }
+    }
+
+    pub fn add_record(&mut self, value: f32) -> Result<&str,&str> {
+        let now = Utc::now();
+
+        let day : u32 = now.day();
+        let month : u32 = now.day();
+        let year : u32 = now.day();
+
+        // If date is today
+        if self.modified_date.day == day && self.modified_date.month == month && self.modified_date.year == year {
+            let index = self.records.len() - 1;
+            self.records[index] = value;
+            self.save_date(day, month, year);
+            Ok("Modified today's record correctly")
+        } else {
+            self.records.push(value);
+            self.save_date(day, month, year);
+
+            Ok("Saved today's record correctly")
+        }
+    }
+
+    fn save_date(&mut self, day: u32, month: u32, year: u32) {
+        self.modified_date.day = day;
+        self.modified_date.month = month;
+        self.modified_date.year = year;
     }
 }

--- a/src/tally.rs
+++ b/src/tally.rs
@@ -1,0 +1,16 @@
+#[derive(Clone)]
+#[derive (Debug)]
+pub struct UserTally {
+    pub name: String,
+    pub records: Vec<i32>
+}
+
+impl UserTally {
+    // Constructor for UserTally
+    pub fn new(username: &str) -> UserTally {
+        UserTally {
+            name: username.to_string(),
+            records: Vec::new()
+        }
+    }
+}


### PR DESCRIPTION
Created a UserTally struct that holds the name, the scores reported by the user, and the last modification date (more information could be added on later)

With the creation of this new struct, I modified the user hashmap so that instead of having the user id mapped to the (String) name, it is now mapped directly to the UserTally, which includes all user data (including the name)

With the user now able to hold records, I added a new `/record` command, which takes a float value as input, and adds it into the user records (or modifies it, if another record has been set on the same day)

![record_command](https://user-images.githubusercontent.com/8825521/145692999-27fa79de-900b-441c-895f-8a7876c93e2f.jpg)

